### PR TITLE
Fixed when the sheet has no values

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "karma start --no-auto-watch --single-run",
     "test:watch": "karma start --browsers Chrome",
     "build": "tsc",
+  	"dev": "tsc --watch",
     "doc": "typedoc --plugin typedoc-plugin-markdown --out ./temp ./src",
     "release": "release-it"
   },


### PR DESCRIPTION
If document has a sheet with nothing in it, it caused errors.
We should not display an empty sheet

+ fixed an error when iterating on the columns, would not render if the only row was A (would not enter the while)